### PR TITLE
docs: 完善README中的MCP配置信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,118 @@ node dist/index.js --token YOUR_API_TOKEN --debug
 - `--url`: API服务地址（可选，默认：https://modao.cc）
 - `--debug`: 启用调试模式（可选）
 
+## MCP客户端配置
+
+### 通用配置
+
+适用于所有支持MCP的客户端：
+
+```json
+{
+  "mcpServers": {
+    "modao-proto-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modao-mcp/modao-proto-mcp",
+        "--token=YOUR_TOKEN",
+        "--url=https://modao.cc"
+      ]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`  
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
+**Linux:** `~/.config/claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "modao-proto-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modao-mcp/modao-proto-mcp",
+        "--token=YOUR_TOKEN",
+        "--url=https://modao.cc"
+      ]
+    }
+  }
+}
+```
+
+### Cursor
+
+在 `settings.json` 中添加：
+
+```json
+{
+  "mcp.servers": {
+    "modao-proto-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modao-mcp/modao-proto-mcp",
+        "--token=YOUR_TOKEN",
+        "--url=https://modao.cc"
+      ]
+    }
+  }
+}
+```
+
+### Windsurf
+
+在 `~/.windsurf/config.json` 中添加：
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "modao-proto-mcp": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@modao-mcp/modao-proto-mcp",
+          "--token=YOUR_TOKEN",
+          "--url=https://modao.cc"
+        ]
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+在 `~/.claude-code/config.json` 中添加：
+
+```json
+{
+  "mcpServers": {
+    "modao-proto-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modao-mcp/modao-proto-mcp",
+        "--token=YOUR_TOKEN",
+        "--url=https://modao.cc"
+      ]
+    }
+  }
+}
+```
+
+### 常见问题
+
+**获取 Token：** 如果 token 报错，请登录 [modao.cc](https://modao.cc) 或 [modao.cc/ai](https://modao.cc/ai)，点击右上角头像 → 令牌设置 → 创建令牌
+
+**积分不足：** 如果 gen_html 无法生成（积分不够），请到 [modao.cc/ai](https://modao.cc/ai) 进行积分充值
+
 ## 工具列表
 
 ### 1. gen_html
@@ -285,7 +397,7 @@ MIT License
 
 ## 更新日志
 
-### v1.3.0 (当前版本)
+### v1.3.7 (当前版本)
 - 🔄 优化HTML导入流程，使用key进行导入操作
 - 📝 改进工具描述和参数说明
 - 🛠️ 简化工作流程，移除组织文件树功能


### PR DESCRIPTION
## 概述
完善了README中的MCP（Model Context Protocol）配置信息，提供更好的用户体验。

## 主要改进
- 🔄 **更新版本号**：更新到v1.3.7
- 📦 **改进配置方式**：从本地node路径改为npx方式，使用`@modao-mcp/modao-proto-mcp`包
- 📋 **新增通用配置**：提供适用于所有MCP客户端的统一配置格式
- 🎯 **简化说明**：移除冗余信息，只保留核心JSON配置代码
- 🔗 **添加实用信息**：
  - Token获取方式：登录modao.cc/ai → 头像 → 令牌设置 → 创建令牌
  - 积分充值说明：当gen_html积分不足时，可到modao.cc/ai进行充值

## 支持的客户端
- Claude Desktop（Windows/macOS/Linux）
- Cursor
- Windsurf 
- Claude Code

## 配置示例
现在用户可以使用更简洁的npx方式：
```json
{
  "mcpServers": {
    "modao-proto-mcp": {
      "command": "npx",
      "args": [
        "-y",
        "@modao-mcp/modao-proto-mcp",
        "--token=YOUR_TOKEN",
        "--url=https://modao.cc"
      ]
    }
  }
}
```

这个改进让用户无需本地构建项目，直接使用发布的npm包即可。